### PR TITLE
add forum link, fix copyright date

### DIFF
--- a/website/src/.vuepress/components/SiteFooter.vue
+++ b/website/src/.vuepress/components/SiteFooter.vue
@@ -2,7 +2,7 @@
   <div id="site-footer">
     <div class="site-container">
       <form-email />
-      <p>&copy; Virgo 2021&mdash;</p>
+      <p>&copy; Virgo 2019&mdash;</p>
     </div>
   </div>
 </template>

--- a/website/src/.vuepress/components/SiteHeader.vue
+++ b/website/src/.vuepress/components/SiteHeader.vue
@@ -10,6 +10,7 @@
         <!--<a href="/about/GLOSSARY">Glossary</a>-->
         <!--<a href="./LAWS">Laws</a>-->
         <!--<a href="./Owners">Owners</a>-->
+        <a href="https://forum.virgo.org">Forum</a>
         <a href="https://github.com/virgo-project/virgo" target="_blank"
           >Contribute</a
         >


### PR DESCRIPTION
Website updates
- [x] adds a link to the Virgo Forum in the site header
- [x] fixes the copyright date to 2019

Note that the forum is currently only in a read-only mode I'm in the process of setting up billing. Will be able to merge this PR once the forum is working again.

Also we should have a discussion of forum vs discord, at least which one we want to prioritize...